### PR TITLE
For -12: Modify examples to have sha256 sum

### DIFF
--- a/pkcs#7-test/rightful_owner/bootstrapping-data.xml
+++ b/pkcs#7-test/rightful_owner/bootstrapping-data.xml
@@ -6,12 +6,9 @@
       <name>
         boot-image-v3.2R1.6.img
       </name>
-      <md5>
-        SomeMD5String
-      </md5>
-      <sha1>
-        SomeSha1String
-      </sha1>
+      <sha256>
+        SomeSha256String
+      </sha256>
       <uri>
         ftp://ftp.example.com/path/to/file
       </uri>

--- a/refs/ex-api-bootstrap-information-signed.xml
+++ b/refs/ex-api-bootstrap-information-signed.xml
@@ -8,12 +8,9 @@
       <name>
         boot-image-v3.2R1.6.img
       </name>
-      <md5>
-        SomeMD5String
-      </md5>
-      <sha1>
-        SomeSha1String
-      </sha1>
+      <sha256>
+        SomeSha256String
+      </sha256>
       <uri>
         /path/to/on/same/bootserver
       </uri>

--- a/refs/ex-api-bootstrap-information-unsigned.xml
+++ b/refs/ex-api-bootstrap-information-unsigned.xml
@@ -8,12 +8,9 @@
       <name>
         boot-image-v3.2R1.6.img
       </name>
-      <md5>
-        SomeMD5String
-      </md5>
-      <sha1>
-        SomeSha1String
-      </sha1>
+      <sha256>
+        SomeSha256String
+      </sha256>
       <uri>
         ftp://ftp.example.com/path/to/file
       </uri>

--- a/refs/ex-file-bootstrap-information.xml
+++ b/refs/ex-file-bootstrap-information.xml
@@ -6,12 +6,9 @@
     <name>
       boot-image-v3.2R1.6.img
     </name>
-    <md5>
-      SomeMD5String
-    </md5>
-    <sha1>
-      SomeSha1String
-    </sha1>
+    <sha256>
+      SomeSha256String
+    </sha256>
     <uri>
       file:///some/path/to/raw/file
     </uri>


### PR DESCRIPTION
Bootimage-information mentions sha256 sum while examples still have md5/sha1 sum.